### PR TITLE
Revert to old tiles, our Maptiler quota was exceeded

### DIFF
--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -52,8 +52,8 @@ export function TheMap(props: Props) {
       zoomControl={false}
       viewport={viewport}>
       <TileLayer
-        attribution='<a href="https://www.maptiler.com/copyright/" target="_blank">© MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
-        url="https://api.maptiler.com/maps/basic/{z}/{x}/{y}.png?key=kkvVQYrpRAgd0J55hJz5"
+        attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         tileSize={512}
         zoomOffset={-1}
         minZoom={1}


### PR DESCRIPTION
The site doesn't operate correctly at the moment because our free quota provided by Maptiler was exceeded. While we're in search of a solution, we revert to the classic tiles for now.