### PR TITLE
Aesthetic tweaks - make route segments thicker and station markers smaller

### DIFF
--- a/src/app.module.scss
+++ b/src/app.module.scss
@@ -11,12 +11,3 @@
 .map {
   flex-grow: 1;
 }
-
-/** make the segments that form the routes thicker, otherwise the thin lines cannot be easily
-*   seen when default OSM tiles are used.
-*   TODO find out why the more specific selector `path.leaflet-interactive` doesn't work
-*/
-path {
-  stroke-width: 10px;
-  stroke-opacity: 0.8;
-}

--- a/src/app.module.scss
+++ b/src/app.module.scss
@@ -11,3 +11,11 @@
 .map {
   flex-grow: 1;
 }
+
+/** make the segments that form the routes thicker, otherwise the thin lines cannot be easily
+*   seen when default OSM tiles are used.
+*   TODO find out why the more specific selector `path.leaflet-interactive` doesn't work
+*/
+path {
+  stroke-width: 10px;
+}

--- a/src/app.module.scss
+++ b/src/app.module.scss
@@ -18,4 +18,5 @@
 */
 path {
   stroke-width: 10px;
+  stroke-opacity: 0.8;
 }

--- a/src/components/routes-segments.component.tsx
+++ b/src/components/routes-segments.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { FeatureCollection, LineString } from 'geojson'
 import { GeoJSON } from 'react-leaflet'
 import { ErrorBoundary } from '../shared/error-boundary'
@@ -21,7 +21,7 @@ export function RoutesSegments({ selectedRoutes }) {
 
   return (
     <ErrorBoundary>
-      <GeoJSON style={getSegmentStyle} key={segmentsUpdatedCount} data={segments} />
+      <GeoJSON style={getSegmentStyle} key={segmentsUpdatedCount} data={segments} opacity={0.8} weight={10} />
     </ErrorBoundary>
   )
 }

--- a/src/components/routes-stations.component.tsx
+++ b/src/components/routes-stations.component.tsx
@@ -4,15 +4,19 @@ import { Icon, marker, Layer } from 'leaflet'
 import { GeoJSON } from 'react-leaflet'
 import uniqBy from 'lodash.uniqby'
 import { ErrorBoundary } from '../shared/error-boundary'
-import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+import markerIcon from '../icons/station.svg'
+
+// find a way to choose a different size, depending on the zoom level
+const markerLarge = 20
+const markerSmall = 15
+const markerTiny = 8
 
 const icon = new Icon({
   iconUrl: markerIcon,
-  shadowUrl: markerShadow,
-  // `markerIcon` size is 25x41
+
   // https://leafletjs.com/reference-1.5.0.html#icon-iconanchor
-  iconAnchor: [12, 41],
+  iconAnchor: [markerTiny / 2, markerTiny / 2],
+  iconSize: [markerTiny, markerTiny],
 })
 
 export function RoutesStations({ selectedRoutes }) {

--- a/src/icons/station.svg
+++ b/src/icons/station.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <svg fill="red" enable-background="new 0 0 100 100" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="40" stroke="black" stroke-width="8" fill="white" />
+</svg>

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -40,12 +40,6 @@ export function TheMap(props: Props) {
     [showUserLocation],
   )
 
-  function onZoom(event) {
-    // change the size and anchor points of of the station markers
-    console.log(`Current zoom level=${event.target.getZoom()}`)
-    console.log(event.target)
-  }
-
   return (
     <Map
       ref={mapRef}
@@ -56,7 +50,6 @@ export function TheMap(props: Props) {
       maxZoom={19}
       className={className}
       zoomControl={false}
-      onzoomend={onZoom}
       viewport={viewport}>
       <TileLayer
         attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -40,6 +40,12 @@ export function TheMap(props: Props) {
     [showUserLocation],
   )
 
+  function onZoom(event) {
+    // change the size and anchor points of of the station markers
+    console.log(`Current zoom level=${event.target.getZoom()}`)
+    console.log(event.target)
+  }
+
   return (
     <Map
       ref={mapRef}
@@ -50,6 +56,7 @@ export function TheMap(props: Props) {
       maxZoom={19}
       className={className}
       zoomControl={false}
+      onzoomend={onZoom}
       viewport={viewport}>
       <TileLayer
         attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -60,7 +60,7 @@ export function TheMap(props: Props) {
       viewport={viewport}>
       <TileLayer
         attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url="https://maptiles.railean.net/styles/klokantech-basic/{z}/{x}/{y}.png"
         tileSize={512}
         zoomOffset={-1}
         minZoom={1}


### PR DESCRIPTION
This PR adds some aesthetic improvements

- station markers are smaller (though they still have a constant size, at least they don't clutter the map)
- station markers are SVG
- route segments are thicker, to make them more prominent
- using self-hosted map tiles